### PR TITLE
resolve vulnerabilities in package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,16 @@
     "url": "https://github.com/TestArmada/magellan-fast-bail-strategy/issues"
   },
   "homepage": "https://github.com/TestArmada/magellan-fast-bail-strategy#readme",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "chai": "^3.4.1",
     "chai-as-promised": "^6.0.0",
-    "codecov": "^1.0.1",
-    "eslint": "^3.12.2",
+    "codecov": "^3.8.0",
+    "eslint": "^7.13.0",
     "eslint-config-walmart": "^1.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^8.2.1"
   }
 }


### PR DESCRIPTION
Area fixed:

- upgrade package eslint to version 4.18.2 or greater
- upgrade package codecov to version 3.6.5 or greater

mocha is updated due to transitive dependencies